### PR TITLE
vlib_events: update establish_listener() declaration

### DIFF
--- a/vlib_events.c
+++ b/vlib_events.c
@@ -197,7 +197,7 @@ static void dispatch_event(struct nlmsghdr *nlh)
 	process_event(fc_nle);
 }
 
-static void *establish_listener()
+static void *establish_listener(void *unused)
 {
 	struct msghdr msg;
 	struct sockaddr_nl src_addr, dest_addr;


### PR DESCRIPTION
The C23 standard is strict about function declarations and () means (void) aka no argument. Update establish_listener() declaration so it matches what pthread_create(3) expects.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2340768
Related: https://fedoraproject.org/wiki/Changes/GNUToolchainF42