### PR TITLE
fix formatting strings in zfcp_ping and zfcp_show

### DIFF
--- a/fc_tools/zfcp_ping.c
+++ b/fc_tools/zfcp_ping.c
@@ -180,7 +180,8 @@ HBA_STATUS send_fc_ping(struct adapter_attr *aa, char *dest, unsigned int token,
 				       (*tp)++, update_ts(&start, &end));
 			else
 				printf("\techo received from D_ID (0x%x) "
-				       "tok=%d time=%0.03f ms\n", dest_val,
+				       "tok=%d time=%0.03f ms\n",
+				       (uint32_t)dest_val,
 				       (*tp)++, update_ts(&start, &end));
 			sleep(1);
 			count--;

--- a/fc_tools/zfcp_ping.c
+++ b/fc_tools/zfcp_ping.c
@@ -133,7 +133,7 @@ HBA_STATUS send_fc_ping(struct adapter_attr *aa, char *dest, unsigned int token,
         }
 
 	if (display_detail & VERBOSE)
-		printf("Sending PNG from BUS_ID=0.0.%x WWPN=0x%016llx "
+		printf("Sending PNG from BUS_ID=0.0.%x WWPN=0x%016lx "
 		       "ID=0x%x dev=%s speed=%s\n", aa->bus_id, aa->wwpn, 
 		       aa->d_id, aa->dev_name, speed[aa->speed]);
 	else

--- a/fc_tools/zfcp_show.c
+++ b/fc_tools/zfcp_show.c
@@ -736,7 +736,7 @@ int main(int argc, char *argv[]) {
         if (aa) {
 		if (display_detail & VERBOSE)
 			printf("Using adapter BUS_ID    0.0.%x\n"
-			       "              Name      0x%016llx\n" 
+			       "              Name      0x%016lx\n"
 			       "              N_Port_ID 0x%x\n" 
 			       "              OS-Device %s\n"
 			       "              Speed     %s\n",


### PR DESCRIPTION
- the wwpn struct member is `uint64_t`, so update the formatting string to `lx` as we are building for 64-bit platforms. Another option would be to use `PRIx64` from `<inttypes.h>.
- the `d_id` member is `uint32_t`, so rather typecast the local variable to it and keep the `x` formatter.